### PR TITLE
Update WildFly Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.wildfly.plugins</groupId>
 				<artifactId>wildfly-maven-plugin</artifactId>
-				<version>1.1.0.Alpha11</version>
+				<version>2.0.2.Final</version>
 				<configuration>
 					<wildfly.username>${wildfly.username}</wildfly.username>
 					<wildfly.password>${wildfly.password}</wildfly.password>


### PR DESCRIPTION
This update solves the following error message during the deploy stage:
```
[ERROR] Failed to execute goal org.wildfly.plugins:wildfly-maven-plugin:1.1.0.Alpha11:deploy (default-cli) on project CooperativeEditor: Execution default-cli of goal org.wildfly.plugins:wildfly-maven-plugin:1.1.0.Alpha11:deploy failed: Plugin org.wildfly.plugins:wildfly-maven-plugin:1.1.0.Alpha11 or one of its dependencies could not be resolved: Could not find artifact sun.jdk:jconsole:jar:jdk at specified path /usr/lib/jvm/java-11-openjdk-amd64/../lib/jconsole.jar -> [Help 1]
```